### PR TITLE
Dense

### DIFF
--- a/gnina/models.py
+++ b/gnina/models.py
@@ -1,9 +1,8 @@
 from collections import OrderedDict
+from typing import Tuple, Union
 
 import torch
 from torch import nn
-
-from typing import Tuple
 
 
 class Default2017(nn.Module):
@@ -14,6 +13,12 @@ class Default2017(nn.Module):
     ----------
     input_dims: tuple
         Model input dimensions (channels, depth, height, width)
+
+    Notes
+    -----
+    This architectre was translated from the following Caffe model:
+
+        https://github.com/gnina/models/blob/master/crossdocked_paper/default2017.model
     """
 
     def __init__(self, input_dims: Tuple):
@@ -130,6 +135,12 @@ class Default2018(nn.Module):
     ----------
     input_dims: tuple
         Model input dimensions (channels, depth, height, width)
+
+    Notes
+    -----
+    This architectre was translated from the following Caffe model:
+
+        https://github.com/gnina/models/blob/master/crossdocked_paper/default2018.model
     """
 
     def __init__(self, input_dims: Tuple):
@@ -260,3 +271,88 @@ class Default2018(nn.Module):
         affinity = self.affinity(x)
 
         return pose_raw, affinity
+
+
+class DenseBlock(nn.Module):
+    """
+    DenseBlock for Dense model.
+
+    Parameters
+    ----------
+    in_features: int
+        Input features for the first layer
+    out_features: int
+        Output features for all convolutional layers
+    num_convs: int
+        Number of convolutions
+    tag: Union[int, str]
+        Tag identifying the DenseBlock
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        block_features: int = 16,
+        num_convs: int = 4,
+        tag: Union[int, str] = "",
+    ):
+
+        super().__init__()
+
+        self.blocks = nn.ModuleList()
+
+        self.block_features = block_features
+        self.num_convs = num_convs
+
+        in_features_layer = in_features
+        for idx in range(num_convs):
+            block: OrderedDict[str, nn.Module] = OrderedDict()
+            block[f"data_enc_level{tag}_batchnorm_conv{idx}"] = nn.BatchNorm3d(
+                in_features_layer,
+                affine=True,  # Same effect as "Scale" layer in Caffe
+            )
+            block[f"data_enc_level{tag}_conv{idx}"] = nn.Conv3d(
+                in_channels=in_features_layer,
+                out_channels=block_features,
+                kernel_size=3,
+                padding=1,
+            )
+            block[f"data_enc_level{tag}_conv{idx}_relu"] = nn.ReLU()
+
+            self.blocks.append(nn.Sequential(block))
+
+            # The next layer takes all previous features as input
+            in_features_layer += block_features
+
+        # TODO: Check that Caffe's Xavier is xavier_uniform_ (not xavier_normal_)
+        # Xavier initialization for convolutional and linear layers
+        for m in self.modules():
+            if isinstance(m, nn.Conv3d):
+                nn.init.xavier_uniform_(m.weight.data)
+
+    def forward(self, x: torch.Tensor):
+        """
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input tensor
+        """
+
+        # TODO: Make more efficient by using keeping concatenated outputs
+
+        # Store output of previous layers
+        # Used as input of next layer
+        outputs = [x]
+
+        for block in self.blocks:
+            # Forward propagation to single block
+            x = block(x)
+
+            # Store current block output
+            outputs.append(x)
+
+            # Concatenate all previous outputs as next input
+            # Concatenate on channels
+            x = torch.cat(outputs, dim=1)
+
+        return x

--- a/gnina/tests/test_models.py
+++ b/gnina/tests/test_models.py
@@ -1,7 +1,10 @@
-import torch
 import pytest
+import torch
 
-from gnina.models import Default2017, Default2018
+from gnina.models import Default2017, Default2018, DenseBlock
+
+# TODO: Allow to deactivate cuda when running tests
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 @pytest.fixture
@@ -16,11 +19,11 @@ def dims():
 
 @pytest.fixture
 def x(batch_size, dims):
-    return torch.normal(mean=0, std=1, size=(batch_size, *dims))
+    return torch.normal(mean=0, std=1, size=(batch_size, *dims), device=device)
 
 
 def test_default2017_forward(batch_size, dims, x):
-    model = Default2017(input_dims=dims)
+    model = Default2017(input_dims=dims).to(device)
     pose_raw, affinity = model(x)
 
     assert pose_raw.shape == (batch_size, 2)
@@ -28,8 +31,23 @@ def test_default2017_forward(batch_size, dims, x):
 
 
 def test_default2018_forward(batch_size, dims, x):
-    model = Default2018(input_dims=dims)
+    model = Default2018(input_dims=dims).to(device)
     pose_raw, affinity = model(x)
 
     assert pose_raw.shape == (batch_size, 2)
     assert affinity.shape == (batch_size, 1)
+
+
+@pytest.mark.parametrize("num_convs", [1, 4])
+@pytest.mark.parametrize("block_features", [8, 16])
+def test_denseblock_forward(batch_size, x, block_features, num_convs):
+    in_features = x.shape[1]
+
+    block = DenseBlock(
+        in_features, block_features=block_features, num_convs=num_convs
+    ).to(device)
+    x = block(x)
+
+    # in_features from input
+    # block_features for each of the convolutional layers
+    assert x.shape[1] == block_features * num_convs + in_features


### PR DESCRIPTION
`dense` model architecture.

```text
Dense(
  (features): Sequential(
    (data_enc_init_pool): MaxPool3d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
    (data_enc_init_conv): Conv3d(32, 32, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
    (data_enc_init_conv_relu): ReLU()
    (dense_block_0): DenseBlock(
      (blocks): ModuleList(
        (0): Sequential(
          (data_enc_level0_batchnorm_conv0): BatchNorm3d(32, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level0_conv0): Conv3d(32, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level0_conv0_relu): ReLU()
        )
        (1): Sequential(
          (data_enc_level0_batchnorm_conv1): BatchNorm3d(48, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level0_conv1): Conv3d(48, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level0_conv1_relu): ReLU()
        )
        (2): Sequential(
          (data_enc_level0_batchnorm_conv2): BatchNorm3d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level0_conv2): Conv3d(64, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level0_conv2_relu): ReLU()
        )
        (3): Sequential(
          (data_enc_level0_batchnorm_conv3): BatchNorm3d(80, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level0_conv3): Conv3d(80, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level0_conv3_relu): ReLU()
        )
      )
    )
    (data_enc_level0_bottleneck): Conv3d(96, 96, kernel_size=(1, 1, 1), stride=(1, 1, 1))
    (data_enc_level0_bottleneck_relu): ReLU()
    (data_enc_level1_pool): MaxPool3d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
    (dense_block_1): DenseBlock(
      (blocks): ModuleList(
        (0): Sequential(
          (data_enc_level1_batchnorm_conv0): BatchNorm3d(96, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level1_conv0): Conv3d(96, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level1_conv0_relu): ReLU()
        )
        (1): Sequential(
          (data_enc_level1_batchnorm_conv1): BatchNorm3d(112, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level1_conv1): Conv3d(112, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level1_conv1_relu): ReLU()
        )
        (2): Sequential(
          (data_enc_level1_batchnorm_conv2): BatchNorm3d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level1_conv2): Conv3d(128, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level1_conv2_relu): ReLU()
        )
        (3): Sequential(
          (data_enc_level1_batchnorm_conv3): BatchNorm3d(144, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level1_conv3): Conv3d(144, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level1_conv3_relu): ReLU()
        )
      )
    )
    (data_enc_level1_bottleneck): Conv3d(160, 160, kernel_size=(1, 1, 1), stride=(1, 1, 1))
    (data_enc_level1_bottleneck_relu): ReLU()
    (data_enc_level2_pool): MaxPool3d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
    (dense_block_2): DenseBlock(
      (blocks): ModuleList(
        (0): Sequential(
          (data_enc_level2_batchnorm_conv0): BatchNorm3d(160, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level2_conv0): Conv3d(160, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level2_conv0_relu): ReLU()
        )
        (1): Sequential(
          (data_enc_level2_batchnorm_conv1): BatchNorm3d(176, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level2_conv1): Conv3d(176, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level2_conv1_relu): ReLU()
        )
        (2): Sequential(
          (data_enc_level2_batchnorm_conv2): BatchNorm3d(192, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level2_conv2): Conv3d(192, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level2_conv2_relu): ReLU()
        )
        (3): Sequential(
          (data_enc_level2_batchnorm_conv3): BatchNorm3d(208, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (data_enc_level2_conv3): Conv3d(208, 16, kernel_size=(3, 3, 3), stride=(1, 1, 1), padding=(1, 1, 1))
          (data_enc_level2_conv3_relu): ReLU()
        )
      )
    )
    (data_enc_level2_global_pool): MaxPool3d(kernel_size=(6, 6, 6), stride=(6, 6, 6), padding=0, dilation=1, ceil_mode=False)
  )
  (pose): Sequential(
    (pose_output): Linear(in_features=224, out_features=2, bias=True)
  )
  (affinity): Sequential(
    (affinity_output): Linear(in_features=224, out_features=1, bias=True)
  )
)
```