### PR TITLE
Use molgrid iteration schemes

### DIFF
--- a/gnina/dataloaders.py
+++ b/gnina/dataloaders.py
@@ -44,6 +44,20 @@ class GriddedExamplesLoader:
         self.dims = grid_maker.grid_dimensions(self.num_types)
 
     def __len__(self):
+        """
+        Return length of the epoch (number of examples).
+
+        Notes
+        -----
+        The number of examples per epoch depends on the :code:`molgrid.IterationScheme`
+        used. Without balancing nor stratification, the number of examples per epoch is
+        the same for :code:`molgrid.IterationScheme.SmalleEpoch` and
+        :code:`molgrid.IterationScheme.SmalleEpoch`. For balanced sampling, which sample
+        the sanem number of positive and negative examples, the number of examples in a
+        small epoch (examples seen at most once) is twice the size of the minority class
+        while for a large epoch (examples seen at least once) it is twice the size of
+        the majority class.
+        """
         settings = self.example_provider.settings()
 
         if settings.iteration_scheme == molgrid.IterationScheme.SmallEpoch:
@@ -53,7 +67,8 @@ class GriddedExamplesLoader:
         else:
             raise ValueError("Unknown iteration scheme {settings.iteration_scheme}.")
 
-    # TODO: Avoid padding with next epoch? (Does this happen with the currenti iteration scheme?)
+    # TODO: Avoid padding with next epoch?
+    # TODO: Does this happen with the currenti iteration scheme?)
     def __next__(self):
         """
         Get next batch of gridded examples and corresponding labels.

--- a/gnina/tests/test_dataloaders.py
+++ b/gnina/tests/test_dataloaders.py
@@ -29,17 +29,19 @@ def dataroot() -> str:
 def test_GriddedExamplesLoader(trainfile, dataroot, device):
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
-    args = training.options([trainfile, "-d", dataroot, "--no_shuffle"])
+    args = training.options(
+        [trainfile, "-d", dataroot, "--no_shuffle", "--batch_size", "1"]
+    )
 
-    e, gmaker = training._setup_example_provider_and_grid_maker(args)
+    e = training._setup_example_provider(args.trainfile, args)
+    gmaker = training._setup_grid_maker(args)
 
     dataset = GriddedExamplesLoader(
-        batch_size=1, example_provider=e, grid_maker=gmaker, device=device
+        example_provider=e, grid_maker=gmaker, device=device
     )
 
     assert len(dataset) == 3
     assert dataset.num_labels == 3
-    assert dataset.num_batches == 3
 
     for _ in range(len(dataset)):
         grids, labels = next(dataset)
@@ -50,20 +52,92 @@ def test_GriddedExamplesLoader(trainfile, dataroot, device):
         next(dataset)
 
 
+def test_GriddedExamplesLoader_epoch_type(trainfile, dataroot, device):
+    # Do not shuffle examples randomly when loading the batch
+    # This ensures reproducibility
+    args = training.options(
+        [trainfile, "-d", dataroot, "--no_shuffle", "--batch_size", "1"]
+    )
+
+    e = training._setup_example_provider(args.trainfile, args)
+    gmaker = training._setup_grid_maker(args)
+
+    dataset_small = GriddedExamplesLoader(
+        example_provider=e,
+        grid_maker=gmaker,
+        device=device,
+    )
+
+    dataset_large = GriddedExamplesLoader(
+        example_provider=e,
+        grid_maker=gmaker,
+        device=device,
+    )
+
+    # If sampling is not balanced, the small and large epoch are the same
+    assert len(dataset_small) == len(dataset_large) == 3
+
+
+def test_GriddedExamplesLoader_iteration_scheme_balanced(trainfile, dataroot, device):
+    # Do not shuffle examples randomly when loading the batch
+    # This ensures reproducibility
+    args = training.options(
+        [trainfile, "-d", dataroot, "--no_shuffle", "--balanced", "--batch_size", "1"]
+    )
+    e = training._setup_example_provider(args.trainfile, args)
+    gmaker = training._setup_grid_maker(args)
+
+    dataset_small = GriddedExamplesLoader(
+        example_provider=e,
+        grid_maker=gmaker,
+        device=device,
+    )
+
+    # Do not shuffle examples randomly when loading the batch
+    # This ensures reproducibility
+    args = training.options(
+        [
+            trainfile,
+            "-d",
+            dataroot,
+            "--no_shuffle",
+            "--balanced",
+            "--batch_size",
+            "1",
+            "--iteration_scheme",
+            "large",
+        ]
+    )
+    e = training._setup_example_provider(args.trainfile, args)
+    gmaker = training._setup_grid_maker(args)
+
+    dataset_large = GriddedExamplesLoader(
+        example_provider=e,
+        grid_maker=gmaker,
+        device=device,
+    )
+
+    # Dataset test.types contains one positive example and two negative examples
+    # Balancing (minority class oversampling) results in different epoch sizes
+    assert len(dataset_small) == 2  # Twice the minority class
+    assert len(dataset_large) == 4  # Twice the majority class
+
+
 def test_GriddedExamplesLoader_batch_size(trainfile, dataroot, device):
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
-    args = training.options([trainfile, "-d", dataroot, "--no_shuffle"])
-
-    e, gmaker = training._setup_example_provider_and_grid_maker(args)
-
-    dataset = GriddedExamplesLoader(
-        batch_size=2, example_provider=e, grid_maker=gmaker, device=device
+    args = training.options(
+        [trainfile, "-d", dataroot, "--no_shuffle", "--batch_size", "2"]
     )
 
-    assert len(dataset) == 2  # Number of batches
+    e = training._setup_example_provider(args.trainfile, args)
+    gmaker = training._setup_grid_maker(args)
+
+    dataset = GriddedExamplesLoader(
+        example_provider=e, grid_maker=gmaker, device=device
+    )
+
     assert dataset.num_labels == 3
-    assert dataset.num_batches == 2
 
     grids, labels = next(dataset)
     assert grids.shape == (2, 28, 48, 48, 48)
@@ -76,17 +150,3 @@ def test_GriddedExamplesLoader_batch_size(trainfile, dataroot, device):
     # Last batch padded with examples from the next epoch
     #   https://gnina.github.io/libmolgrid/python/index.html#molgrid.ExampleProviderSettings.iteration_scheme
     assert torch.allclose(labels, torch.tensor([0, 0], device=device))
-
-
-def test_GriddedExamplesLoader_oversized_batch(trainfile, dataroot):
-    """
-    Test batch bigger than the number of examples
-    """
-    # Do not shuffle examples randomly when loading the batch
-    # This ensures reproducibility
-    args = training.options([trainfile, "-d", dataroot, "--no_shuffle"])
-
-    e, gmaker = training._setup_example_provider_and_grid_maker(args)
-
-    with pytest.raises(ValueError):
-        GriddedExamplesLoader(batch_size=5, example_provider=e, grid_maker=gmaker)

--- a/gnina/tests/test_dataloaders.py
+++ b/gnina/tests/test_dataloaders.py
@@ -26,11 +26,21 @@ def dataroot() -> str:
     return os.path.join(gnina_path, "data", "test")
 
 
-def test_GriddedExamplesLoader(trainfile, dataroot, device):
+@pytest.mark.parametrize("iteration_scheme", ["small", "large"])
+def test_GriddedExamplesLoader(trainfile, dataroot, device, iteration_scheme):
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
     args = training.options(
-        [trainfile, "-d", dataroot, "--no_shuffle", "--batch_size", "1"]
+        [
+            trainfile,
+            "-d",
+            dataroot,
+            "--no_shuffle",
+            "--batch_size",
+            "1",
+            "--iteration_scheme",
+            iteration_scheme,
+        ]
     )
 
     e = training._setup_example_provider(args.trainfile, args)
@@ -40,8 +50,12 @@ def test_GriddedExamplesLoader(trainfile, dataroot, device):
         example_provider=e, grid_maker=gmaker, device=device
     )
 
-    assert len(dataset) == 3
+    assert dataset.num_examples == 3
     assert dataset.num_labels == 3
+
+    # Without balancing the length of the dataset is the same as the number of examples
+    # This is true for both small and large epochs
+    assert len(dataset) == 3
 
     for _ in range(len(dataset)):
         grids, labels = next(dataset)
@@ -52,50 +66,33 @@ def test_GriddedExamplesLoader(trainfile, dataroot, device):
         next(dataset)
 
 
-def test_GriddedExamplesLoader_epoch_type(trainfile, dataroot, device):
+def test_GriddedExamplesLoader_iteration_scheme_balanced_batch_size_1(
+    trainfile, dataroot, device
+):
+    """
+    Notes
+    -----
+    With :code:`batch_size` set to 1 as here, the sampling can't be balanced since the
+    batch only contains a single example.
+    """
+
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
-    args = training.options(
-        [trainfile, "-d", dataroot, "--no_shuffle", "--batch_size", "1"]
-    )
-
-    e = training._setup_example_provider(args.trainfile, args)
-    gmaker = training._setup_grid_maker(args)
-
-    dataset_small = GriddedExamplesLoader(
-        example_provider=e,
-        grid_maker=gmaker,
-        device=device,
-    )
-
-    dataset_large = GriddedExamplesLoader(
-        example_provider=e,
-        grid_maker=gmaker,
-        device=device,
-    )
-
-    # If sampling is not balanced, the small and large epoch are the same
-    assert len(dataset_small) == len(dataset_large) == 3
-
-
-def test_GriddedExamplesLoader_iteration_scheme_balanced(trainfile, dataroot, device):
-    # Do not shuffle examples randomly when loading the batch
-    # This ensures reproducibility
-    args = training.options(
+    args_small = training.options(
         [trainfile, "-d", dataroot, "--no_shuffle", "--balanced", "--batch_size", "1"]
     )
-    e = training._setup_example_provider(args.trainfile, args)
-    gmaker = training._setup_grid_maker(args)
+    e_small = training._setup_example_provider(args_small.trainfile, args_small)
+    gmaker_small = training._setup_grid_maker(args_small)
 
     dataset_small = GriddedExamplesLoader(
-        example_provider=e,
-        grid_maker=gmaker,
+        example_provider=e_small,
+        grid_maker=gmaker_small,
         device=device,
     )
 
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
-    args = training.options(
+    args_large = training.options(
         [
             trainfile,
             "-d",
@@ -108,12 +105,12 @@ def test_GriddedExamplesLoader_iteration_scheme_balanced(trainfile, dataroot, de
             "large",
         ]
     )
-    e = training._setup_example_provider(args.trainfile, args)
-    gmaker = training._setup_grid_maker(args)
+    e_large = training._setup_example_provider(args_large.trainfile, args_large)
+    gmaker_large = training._setup_grid_maker(args_large)
 
     dataset_large = GriddedExamplesLoader(
-        example_provider=e,
-        grid_maker=gmaker,
+        example_provider=e_large,
+        grid_maker=gmaker_large,
         device=device,
     )
 
@@ -121,6 +118,91 @@ def test_GriddedExamplesLoader_iteration_scheme_balanced(trainfile, dataroot, de
     # Balancing (minority class oversampling) results in different epoch sizes
     assert len(dataset_small) == 2  # Twice the minority class
     assert len(dataset_large) == 4  # Twice the majority class
+
+    # With a batch_size of 1, only one batch can be loaded in a small epoch since there
+    # is only one example in the minority class
+    grids, labels = next(dataset_small)
+    assert grids.shape == (1, 28, 48, 48, 48)
+    assert labels.shape == (1,)
+    with pytest.raises(StopIteration):
+        next(dataset_small)
+
+    # With a batch_size of 1, three batches can be loaded in a large epoch since there
+    # are two examples in the manjority class
+    for _ in range(3):
+        grids, labels = next(dataset_large)
+        assert grids.shape == (1, 28, 48, 48, 48)
+        assert labels.shape == (1,)
+    with pytest.raises(StopIteration):
+        next(dataset_large)
+
+
+def test_GriddedExamplesLoader_iteration_scheme_balanced_batch_size_2(
+    trainfile, dataroot, device
+):
+    # Do not shuffle examples randomly when loading the batch
+    # This ensures reproducibility
+    args_small = training.options(
+        [trainfile, "-d", dataroot, "--no_shuffle", "--balanced", "--batch_size", "2"]
+    )
+    e_small = training._setup_example_provider(args_small.trainfile, args_small)
+    gmaker_small = training._setup_grid_maker(args_small)
+
+    dataset_small = GriddedExamplesLoader(
+        example_provider=e_small,
+        grid_maker=gmaker_small,
+        device=device,
+    )
+
+    # Do not shuffle examples randomly when loading the batch
+    # This ensures reproducibility
+    args_large = training.options(
+        [
+            trainfile,
+            "-d",
+            dataroot,
+            "--no_shuffle",
+            "--balanced",
+            "--batch_size",
+            "2",
+            "--iteration_scheme",
+            "large",
+        ]
+    )
+    e_large = training._setup_example_provider(args_large.trainfile, args_large)
+    gmaker_large = training._setup_grid_maker(args_large)
+
+    dataset_large = GriddedExamplesLoader(
+        example_provider=e_large,
+        grid_maker=gmaker_large,
+        device=device,
+    )
+
+    # Dataset test.types contains one positive example and two negative examples
+    # Balancing (minority class oversampling) results in different epoch sizes
+    assert len(dataset_small) == 2  # Twice the minority class
+    assert len(dataset_large) == 4  # Twice the majority class
+
+    # With a batch_size of 2, only one batch can be loaded in a small epoch since there
+    # is only one example in the minority class
+    grids, labels = next(dataset_small)
+    assert grids.shape == (2, 28, 48, 48, 48)
+    assert labels.shape == (2,)
+    # The positive example is sampled once, with one of the negative examples
+    assert torch.allclose(labels, torch.tensor([1, 0], device=device))
+    with pytest.raises(StopIteration):
+        next(dataset_small)
+
+    # With a batch_size of 2, only two batches can be loaded in a large epoch since
+    # there are two examples in the manjority class
+    for _ in range(2):
+        grids, labels = next(dataset_large)
+        assert grids.shape == (2, 28, 48, 48, 48)
+        assert labels.shape == (2,)
+        # The positive example is sampled twice, one for each of the negative examples
+        assert torch.allclose(labels, torch.tensor([1, 0], device=device))
+    with pytest.raises(StopIteration):
+        next(dataset_large)
 
 
 def test_GriddedExamplesLoader_batch_size(trainfile, dataroot, device):

--- a/gnina/tests/test_training.py
+++ b/gnina/tests/test_training.py
@@ -44,7 +44,7 @@ def test_options(trainfile, model, gpu):
     assert args.seed == seed
 
 
-def test_setup_example_provider_and_grid_maker_default(trainfile, dataroot, device):
+def test_setup_example_provider_default(trainfile, dataroot, device):
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
     args = training.options(
@@ -53,11 +53,20 @@ def test_setup_example_provider_and_grid_maker_default(trainfile, dataroot, devi
 
     assert not args.shuffle
 
-    e, gmaker = training._setup_example_provider_and_grid_maker(args)
+    e = training._setup_example_provider(args.trainfile, args)
 
     assert e.num_labels() == 3  # Three labels in small.types
     assert e.size() == 3  # Three examples in small.types
     assert e.num_types() == 28
+
+
+def test_setup_grid_maker_default(trainfile, dataroot, device):
+    args = training.options(
+        [trainfile, "-d", dataroot, "--no_shuffle", "-g", str(device)]
+    )
+
+    gmaker = training._setup_grid_maker(args)
+
     assert gmaker.get_dimension() == pytest.approx(23.5)
     assert gmaker.get_resolution() == pytest.approx(0.5)
     assert gmaker.grid_dimensions(28) == (28, 48, 48, 48)
@@ -66,6 +75,7 @@ def test_setup_example_provider_and_grid_maker_default(trainfile, dataroot, devi
 def test_example_provider(trainfile, dataroot, device):
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
+    batch_size = 2
     args = training.options(
         [
             trainfile,
@@ -76,16 +86,20 @@ def test_example_provider(trainfile, dataroot, device):
             "1",
             "-g",
             str(device),
+            "--batch_size",
+            str(batch_size),
         ]
     )
 
     assert not args.shuffle
 
-    e, gmaker = training._setup_example_provider_and_grid_maker(args)
+    e = training._setup_example_provider(args.trainfile, args)
 
     batch_size = 2
 
-    batch = e.next_batch(batch_size)
+    batch = next(e)
+
+    assert len(batch) == batch_size
 
     labels = torch.zeros(batch_size, device=device)
     affinities = torch.zeros(batch_size, device=device)
@@ -108,18 +122,28 @@ def test_example_provider(trainfile, dataroot, device):
 def test_grid_maker(trainfile, dataroot, device):
     # Do not shuffle examples randomly when loading the batch
     # This ensures reproducibility
+    # Manually set batch size
+    batch_size = 2
     args = training.options(
-        [trainfile, "-d", dataroot, "--no_shuffle", "-g", str(device)]
+        [
+            trainfile,
+            "-d",
+            dataroot,
+            "--no_shuffle",
+            "-g",
+            str(device),
+            "--batch_size",
+            str(batch_size),
+        ]
     )
 
     assert not args.shuffle
 
-    e, gmaker = training._setup_example_provider_and_grid_maker(args)
+    e = training._setup_example_provider(args.trainfile, args)
+    gmaker = training._setup_grid_maker(args)
     dims = gmaker.grid_dimensions(e.num_types())
 
-    batch_size = 2
-
-    batch = e.next_batch(batch_size)
+    batch = next(e)
 
     grid = torch.zeros((batch_size, *dims), device=device)
     assert not any(grid[grid > 0.0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,13 @@ omit =
     */tests/*
     # Omit generated versioneer
     gnina/_version.py
+
+[coverage:report]
+omit =
+    # Omit the tests
+    */tests/*
+    # Omit generated versioneer
+    gnina/_version.py
 exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:


### PR DESCRIPTION
The custom `num_batches` variable was OK for non-balanced, non-stratified sampling but for balanced and stratified sampling `molgrid.IterationScheme` needs to be used in order to define epochs clearly.

* `molgrid.IterationScheme.SmallEpoch`: systems are seen at most once during an epoch
   * For a balanced data set, this means that all examples of the minority class are sampled while examples of the majority class are undersampled
* `molgrid.IterationScheme.LargeEpoch`: systems are seen at least once during an epoch
  * For a balanced data set, this means that all examples of the majority class are sampled while examples of the minority class are oversampled

Here we use the `example_provider` settings in order to define a default `batch_size` and use the underlying iterator with the specified `molgrid.IterationScheme` (which can be user-defined) as a definition of an epoch.

Note: the original implementation uses iterations instead of epochs.

---

Minor changes include:
* `__main__` is now ignored in code coverage; it should only parse arguments and call a function
* `_setup_example_provider_and_grid_maker` is now split into two different functions