### PR TITLE
Automatic (dynamic) learning rate update on plateau of the loss function

### DIFF
--- a/gnina/tests/test_training.py
+++ b/gnina/tests/test_training.py
@@ -185,3 +185,42 @@ def test_training_with_test(trainfile, dataroot, tmpdir, device):
     )
 
     training.training(args)
+
+
+def test_training_lr_scheduler(trainfile, dataroot, tmpdir, device, capsys):
+    # Do not shuffle examples randomly when loading the batch
+    # This ensures reproducibility
+    args = training.options(
+        [
+            trainfile,
+            "--testfile",
+            trainfile,
+            "-d",
+            dataroot,
+            "--no_shuffle",
+            "--batch_size",
+            "1",
+            "--test_every",
+            "2",
+            "--iterations",
+            "5",
+            "-o",
+            str(tmpdir),
+            "-g",
+            str(device),
+            "--seed",
+            "42",
+            "--progress_bar",
+            "--dynamic",
+            "--lr_patience",
+            "1",
+        ]
+    )
+
+    training.training(args)
+
+    # Check that the learning rate changes during training
+    # TODO: Store learning rate internally and check the cache instead
+    captured = capsys.readouterr()
+    assert "Learning rate: 0.01" in captured.out  # Original (default) learning rate
+    assert "Learning rate: 0.001" in captured.out  # Updated learning rate


### PR DESCRIPTION
Add learning rate reduction using `torch.optim.lr_scheduler.ReduceLROnPlateau`.

In contrast with the Caffe implementation, this implementation does not provide early stopping (yet).

Other key differences is that the learning rate update is based on the loss function of the test set (instead of the training set) and that this evaluation is performed based on epochs (instead of iteration). These details might change in future PRs.