### PR TITLE
Add high-resolution models

### DIFF
--- a/gnina/models.py
+++ b/gnina/models.py
@@ -1014,7 +1014,7 @@ class HiResAffinity(nn.Module):
                     ),
                     ("unit2_func", nn.ReLU()),
                     # unit3
-                    ("unit3_pool", nn.MaxPool3d(kernel_size=8, stride=8)),
+                    ("unit3_pool", nn.AvgPool3d(kernel_size=8, stride=8)),
                     (
                         "unit3_conv",
                         nn.Conv3d(

--- a/gnina/models.py
+++ b/gnina/models.py
@@ -588,7 +588,6 @@ class Dense(nn.Module):
         super().__init__()
 
         self.input_dims = input_dims
-        self.predict_affinity = affinity
 
         features: OrderedDict[str, nn.Module] = OrderedDict(
             [
@@ -743,8 +742,6 @@ class DensePose(Dense):
         x = x.view(-1, self.features_out_size)
 
         pose_raw = self.pose(x)
-
-        pose_raw = self.pose(x)
         pose_log = F.log_softmax(pose_raw, dim=1)
 
         return pose_log
@@ -787,19 +784,16 @@ class DenseAffinity(DensePose):
         super().__init__(input_dims, num_blocks, num_block_features, num_block_convs)
 
         # Linear layer for binding affinity prediction
-        if self.predict_affinity:
-            self.affinity = nn.Sequential(
-                OrderedDict(
-                    [
-                        (
-                            "affinity_output",
-                            nn.Linear(
-                                in_features=self.features_out_size, out_features=1
-                            ),
-                        )
-                    ]
-                )
+        self.affinity = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "affinity_output",
+                        nn.Linear(in_features=self.features_out_size, out_features=1),
+                    )
+                ]
             )
+        )
 
         # Xavier initialization for convolutional and linear layers
         for m in self.modules():
@@ -824,6 +818,275 @@ class DenseAffinity(DensePose):
         x = x.view(-1, self.features_out_size)
 
         pose_raw = self.pose(x)
+        pose_log = F.log_softmax(pose_raw, dim=1)
+
+        affinity = self.affinity(x)
+        # Squeeze last (dummy) dimension of affinity prediction
+        # This allows to match the shape (batch_size,) of the target tensor
+        return pose_log, affinity.squeeze(-1)
+
+
+class HiResPose(nn.Module):
+    """
+    GNINA HiResPose model architecture.
+
+    Parameters
+    ----------
+    input_dims: tuple
+        Model input dimensions (channels, depth, height, width)
+
+    Notes
+    -----
+    This architecture was translated from the following Caffe model:
+
+        https://github.com/gnina/models/blob/master/crossdocked_paper/hires_pose.model
+
+    The main difference is that the PyTorch implementation resurns the log softmax.
+
+    This model is implemented only for multi-task pose and affinity prediction.
+    """
+
+    def __init__(self, input_dims: Tuple):
+
+        super().__init__()
+
+        self.input_dims = input_dims
+
+        self.features = nn.Sequential(
+            OrderedDict(
+                [
+                    # unit1
+                    (
+                        "unit1_conv",
+                        nn.Conv3d(
+                            in_channels=input_dims[0],
+                            out_channels=32,
+                            kernel_size=3,
+                            stride=1,
+                            padding=1,
+                        ),
+                    ),
+                    ("unit1_func", nn.ReLU()),
+                    # unit2
+                    ("unit2_pool", nn.MaxPool3d(kernel_size=2, stride=2)),
+                    (
+                        "unit2_conv",
+                        nn.Conv3d(
+                            in_channels=32,
+                            out_channels=64,
+                            kernel_size=3,
+                            stride=1,
+                            padding=1,
+                        ),
+                    ),
+                    ("unit2_func", nn.ReLU()),
+                    # unit3
+                    ("unit3_pool", nn.MaxPool3d(kernel_size=2, stride=2)),
+                    (
+                        "unit3_conv",
+                        nn.Conv3d(
+                            in_channels=64,
+                            out_channels=128,
+                            kernel_size=3,
+                            stride=1,
+                            padding=1,
+                        ),
+                    ),
+                    ("unit3_func", nn.ReLU()),
+                ]
+            )
+        )
+
+        # Two MaxPool3d layers with kernel_size=2 and stride=2
+        # Spatial dimensions are halved at each pooling step
+        self.features_out_size = (
+            input_dims[1] // 4 * input_dims[2] // 4 * input_dims[3] // 4 * 128
+        )
+
+        # Linear layer for pose prediction
+        self.pose = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "pose_output",
+                        nn.Linear(in_features=self.features_out_size, out_features=2),
+                    )
+                ]
+            )
+        )
+
+        # Linear layer for binding affinity prediction
+        self.affinity = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "affinity_output",
+                        nn.Linear(in_features=self.features_out_size, out_features=1),
+                    )
+                ]
+            )
+        )
+
+        # Xavier initialization for convolutional and linear layers
+        for m in self.modules():
+            if isinstance(m, nn.Conv3d) or isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight.data)
+
+    def forward(self, x: torch.Tensor):
+        """
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input tensor
+
+        Notes
+        -----
+        The pose score is the log softmax of the output of the last linear layer.
+        """
+        x = self.features(x)
+
+        print("FEATURES SHAPE:", x.shape)
+
+        # Reshape based on number of channels
+        # Global max pooling reduced spatial dimensions to single value
+        x = x.view(-1, self.features_out_size)
+
+        pose_raw = self.pose(x)
+        pose_log = F.log_softmax(pose_raw, dim=1)
+
+        affinity = self.affinity(x)
+        # Squeeze last (dummy) dimension of affinity prediction
+        # This allows to match the shape (batch_size,) of the target tensor
+        return pose_log, affinity.squeeze(-1)
+
+
+class HiResAffinity(nn.Module):
+    """
+    GNINA HiResAffinity model architecture.
+
+    Parameters
+    ----------
+    input_dims: tuple
+        Model input dimensions (channels, depth, height, width)
+
+    Notes
+    -----
+    This architecture was translated from the following Caffe model:
+
+        https://github.com/gnina/models/blob/master/crossdocked_paper/hires_pose.model
+
+    The main difference is that the PyTorch implementation resurns the log softmax.
+
+    This model is implemented only for multi-task pose and affinity prediction.
+    """
+
+    def __init__(self, input_dims: Tuple):
+
+        super().__init__()
+
+        self.input_dims = input_dims
+
+        self.features = nn.Sequential(
+            OrderedDict(
+                [
+                    # unit1
+                    (
+                        "unit1_conv",
+                        nn.Conv3d(
+                            in_channels=input_dims[0],
+                            out_channels=32,
+                            kernel_size=3,
+                            stride=1,
+                            padding=1,
+                        ),
+                    ),
+                    ("unit1_func", nn.ReLU()),
+                    # unit2
+                    (
+                        "unit2_conv",
+                        nn.Conv3d(
+                            in_channels=32,
+                            out_channels=64,
+                            kernel_size=3,
+                            stride=1,
+                            padding=1,
+                        ),
+                    ),
+                    ("unit2_func", nn.ReLU()),
+                    # unit3
+                    ("unit3_pool", nn.MaxPool3d(kernel_size=8, stride=8)),
+                    (
+                        "unit3_conv",
+                        nn.Conv3d(
+                            in_channels=64,
+                            out_channels=128,
+                            kernel_size=5,
+                            stride=1,
+                            padding=2,
+                        ),
+                    ),
+                    ("unit3_func", nn.ELU(alpha=1.0)),
+                    # unit5 (following original naming convention)
+                    ("unit5_pool", nn.MaxPool3d(kernel_size=4, stride=4)),
+                ]
+            )
+        )
+
+        self.features_out_size = (
+            input_dims[1]
+            // (8 * 4)
+            * input_dims[2]
+            // (8 * 4)
+            * input_dims[3]
+            // (8 * 4)
+            * 128
+        )
+
+        # Linear layer for pose prediction
+        self.pose = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "pose_output",
+                        nn.Linear(in_features=self.features_out_size, out_features=2),
+                    )
+                ]
+            )
+        )
+
+        # Linear layer for binding affinity prediction
+        self.affinity = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "affinity_output",
+                        nn.Linear(in_features=self.features_out_size, out_features=1),
+                    )
+                ]
+            )
+        )
+
+        # Xavier initialization for convolutional and linear layers
+        for m in self.modules():
+            if isinstance(m, nn.Conv3d) or isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight.data)
+
+    def forward(self, x: torch.Tensor):
+        """
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input tensor
+
+        Notes
+        -----
+        The pose score is the log softmax of the output of the last linear layer.
+        """
+        x = self.features(x)
+
+        # Reshape based on number of channels
+        # Global max pooling reduced spatial dimensions to single value
+        x = x.view(-1, self.features_out_size)
 
         pose_raw = self.pose(x)
         pose_log = F.log_softmax(pose_raw, dim=1)
@@ -841,4 +1104,6 @@ models_dict = {
     ("default2018", True): Default2018Affinity,
     ("dense", False): DensePose,
     ("dense", True): DenseAffinity,
+    ("hires_pose", True): HiResPose,
+    ("hires_affinity", True): HiResAffinity,
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,8 +15,24 @@ def dims():
 
 
 @pytest.fixture
+def dims_big():
+    """
+    Less channels, but bigger spatial dimensions (like original input)
+    """
+    return (3, 48, 48, 48)
+
+
+@pytest.fixture
 def x(batch_size, dims, device):
     return torch.normal(mean=0, std=1, size=(batch_size, *dims), device=device)
+
+
+@pytest.fixture
+def x_big(batch_size, dims_big, device):
+    """
+    HiResAffinity has as an aggressive pooling, so we need the standard input size.
+    """
+    return torch.normal(mean=0, std=1, size=(batch_size, *dims_big), device=device)
 
 
 @pytest.mark.parametrize("model", ["default2017", "default2018", "dense"])
@@ -30,13 +46,27 @@ def test_forward_pose(batch_size, dims, x, device, model):
     assert pose_raw.shape == (batch_size, 2)
 
 
-@pytest.mark.parametrize("model", ["default2017", "default2018", "dense"])
+@pytest.mark.parametrize("model", ["default2017", "default2018", "dense", "hires_pose"])
 def test_forward_affinity(batch_size, dims, x, device, model):
     """
     Test forward pass of models for pose and binding affinity prediction.
     """
     m = models_dict[(model, True)](input_dims=dims).to(device)
     pose_log, affinity = m(x)
+
+    assert pose_log.shape == (batch_size, 2)
+    assert affinity.shape == (batch_size,)
+
+
+@pytest.mark.parametrize(
+    "model", ["default2017", "default2018", "dense", "hires_pose", "hires_affinity"]
+)
+def test_forward_affinity_big(batch_size, dims_big, x_big, device, model):
+    """
+    Test forward pass of models for pose and binding affinity prediction.
+    """
+    m = models_dict[(model, True)](input_dims=dims_big).to(device)
+    pose_log, affinity = m(x_big)
 
     assert pose_log.shape == (batch_size, 2)
     assert affinity.shape == (batch_size,)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,6 +50,10 @@ def test_forward_pose(batch_size, dims, x, device, model):
 def test_forward_affinity(batch_size, dims, x, device, model):
     """
     Test forward pass of models for pose and binding affinity prediction.
+
+    Notes
+    -----
+    All models but :code:`hires_affinity`, which requires larger spatial dimensions.
     """
     m = models_dict[(model, True)](input_dims=dims).to(device)
     pose_log, affinity = m(x)


### PR DESCRIPTION
Add `HiResPose` and `HiResAffinity` models. They only work for combined pose and binding affinity prediction.

This PR also removes spurious double computations of the pose score in some models.