### PR TITLE
Store metrics during training and export final CSV file

### DIFF
--- a/gnina/inference.py
+++ b/gnina/inference.py
@@ -172,6 +172,7 @@ def inference(args):
     evaluator = training._setup_evaluator(model, allmetrics, affinity=affinity)
 
     results = defaultdict(list)
+    metrics_inference = defaultdict(list)
 
     # Print predictions for every batch
     # evaluator.state.output only stores the last batch
@@ -215,10 +216,17 @@ def inference(args):
             stream=outstream,
         )
 
-    df = pd.DataFrame(results)
-
     if args.csv:
-        df.to_csv(os.path.join(args.out_dir, "inference.csv"), float_format="%.5f")
+        pd.DataFrame(results).to_csv(
+            os.path.join(args.out_dir, "inference.csv"), float_format="%.5f"
+        )
+
+        for key, value in evaluator.state.metrics.items():
+            metrics_inference[key].append(value)
+
+        pd.DataFrame(metrics_inference).to_csv(
+            os.path.join(args.out_dir, "metrics_inference.csv", float_format="%.5f")
+        )
 
     # Close log file
     logfile.close()

--- a/gnina/inference.py
+++ b/gnina/inference.py
@@ -225,7 +225,9 @@ def inference(args):
             metrics_inference[key].append(value)
 
         pd.DataFrame(metrics_inference).to_csv(
-            os.path.join(args.out_dir, "metrics_inference.csv"), float_format="%.5f"
+            os.path.join(args.out_dir, "metrics_inference.csv"),
+            float_format="%.5f",
+            index=False,
         )
 
     # Close log file

--- a/gnina/inference.py
+++ b/gnina/inference.py
@@ -225,7 +225,7 @@ def inference(args):
             metrics_inference[key].append(value)
 
         pd.DataFrame(metrics_inference).to_csv(
-            os.path.join(args.out_dir, "metrics_inference.csv", float_format="%.5f")
+            os.path.join(args.out_dir, "metrics_inference.csv"), float_format="%.5f"
         )
 
     # Close log file

--- a/gnina/training.py
+++ b/gnina/training.py
@@ -725,12 +725,16 @@ def training(args):
     trainer.run(train_loader, max_epochs=args.iterations)
 
     pd.DataFrame(metrics_train).to_csv(
-        os.path.join(args.out_dir, "metrics_train.csv"), float_format="%.5f"
+        os.path.join(args.out_dir, "metrics_train.csv"),
+        float_format="%.5f",
+        index=False,
     )
 
     if args.testfile is not None:
         pd.DataFrame(metrics_test).to_csv(
-            os.path.join(args.out_dir, "metrics_test.csv"), float_format="%.5f"
+            os.path.join(args.out_dir, "metrics_test.csv"),
+            float_format="%.5f",
+            index=False,
         )
 
     # Close log file

--- a/gnina/training.py
+++ b/gnina/training.py
@@ -661,16 +661,16 @@ def training(args):
                 stream=outstream,
             )
 
-        metrics = evaluator.state.metrics
+        mts = evaluator.state.metrics
         metrics_train["Epoch"].append(trainer.state.epoch)
-        for key, value in metrics.items():
+        for key, value in mts.items():
             metrics_train[key].append(value)
 
         # Update LR based on the loss on the training set
         if args.lr_dynamic:
-            loss = metrics["Loss (pose)"]
+            loss = mts["Loss (pose)"]
             try:
-                loss += metrics["Loss (affinity)"]
+                loss += mts["Loss (affinity)"]
             except KeyError:
                 # No affinity loss
                 pass
@@ -698,9 +698,8 @@ def training(args):
                     stream=outstream,
                 )
 
-            metrics = evaluator.state.metrics
             metrics_test["Epoch"].append(trainer.state.epoch)
-            for key, value in metrics.items():
+            for key, value in evaluator.state.metrics.items():
                 metrics_test[key].append(value)
 
     # TODO: Save input parameters as well
@@ -731,7 +730,7 @@ def training(args):
 
     if args.testfile is not None:
         pd.DataFrame(metrics_test).to_csv(
-            os.path.join(args.out_dir, "metrics_test.csv", float_format="%.5f")
+            os.path.join(args.out_dir, "metrics_test.csv"), float_format="%.5f"
         )
 
     # Close log file

--- a/gnina/training.py
+++ b/gnina/training.py
@@ -725,11 +725,13 @@ def training(args):
 
     trainer.run(train_loader, max_epochs=args.iterations)
 
-    pd.DataFrame(metrics_train).to_csv(os.path.join(args.out_dir, "metrics_train.csv"))
+    pd.DataFrame(metrics_train).to_csv(
+        os.path.join(args.out_dir, "metrics_train.csv"), float_format="%.5f"
+    )
 
     if args.testfile is not None:
         pd.DataFrame(metrics_test).to_csv(
-            os.path.join(args.out_dir, "metrics_test.csv")
+            os.path.join(args.out_dir, "metrics_test.csv", float_format="%.5f")
         )
 
     # Close log file

--- a/gnina/training.py
+++ b/gnina/training.py
@@ -5,10 +5,12 @@ PyTorch implementation of GNINA scoring function's Caffe training script.
 import argparse
 import os
 import sys
+from collections import defaultdict
 from typing import List, Optional
 
 import molgrid
 import numpy as np
+import pandas as pd
 import torch
 from ignite.contrib.handlers import ProgressBar
 from ignite.engine import Engine, Events
@@ -625,6 +627,11 @@ def training(args):
     allmetrics = metrics.setup_metrics(
         affinity, pose_loss, affinity_loss, args.roc_auc, device
     )
+
+    # Storage for metrics
+    metrics_train = defaultdict(list)
+    metrics_test = defaultdict(list)
+
     evaluator = _setup_evaluator(model, allmetrics, affinity=affinity)
 
     # Define LR scheduler
@@ -654,10 +661,13 @@ def training(args):
                 stream=outstream,
             )
 
+        metrics = evaluator.state.metrics
+        metrics_train["Epoch"].append(trainer.state.epoch)
+        for key, value in metrics.items():
+            metrics_train[key].append(value)
+
         # Update LR based on the loss on the training set
         if args.lr_dynamic:
-            metrics = evaluator.state.metrics
-
             loss = metrics["Loss (pose)"]
             try:
                 loss += metrics["Loss (affinity)"]
@@ -688,6 +698,11 @@ def training(args):
                     stream=outstream,
                 )
 
+            metrics = evaluator.state.metrics
+            metrics_test["Epoch"].append(trainer.state.epoch)
+            for key, value in metrics.items():
+                metrics_test[key].append(value)
+
     # TODO: Save input parameters as well
     # TODO: Save best models (lower loss)
     to_save = {"model": model, "optimizer": optimizer}
@@ -709,6 +724,13 @@ def training(args):
         pbar.attach(trainer)
 
     trainer.run(train_loader, max_epochs=args.iterations)
+
+    pd.DataFrame(metrics_train).to_csv(os.path.join(args.out_dir, "metrics_train.csv"))
+
+    if args.testfile is not None:
+        pd.DataFrame(metrics_test).to_csv(
+            os.path.join(args.out_dir, "metrics_test.csv")
+        )
 
     # Close log file
     logfile.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ exclude=
     examples/
 
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E203, E266, E501, W503, C901
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -55,7 +55,6 @@ def test_inference(trainfile, testfile, dataroot, tmpdir, device):
             "42",
             "--label_pos",
             "0",
-            "--csv",
         ]
     )
 
@@ -94,7 +93,6 @@ def test_inference_affinity(trainfile, testfile, dataroot, tmpdir, device):
             str(device),
             "--seed",
             "42",
-            "--csv",
         ]
     )
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -55,10 +55,15 @@ def test_inference(trainfile, testfile, dataroot, tmpdir, device):
             "42",
             "--label_pos",
             "0",
+            "--csv",
         ]
     )
 
     inference.inference(args)
+
+    # Confirm inference output files exist
+    assert os.path.isfile(os.path.join(tmpdir, "inference.csv"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_inference.csv"))
 
 
 def test_inference_affinity(trainfile, testfile, dataroot, tmpdir, device):
@@ -89,6 +94,7 @@ def test_inference_affinity(trainfile, testfile, dataroot, tmpdir, device):
             str(device),
             "--seed",
             "42",
+            "--csv",
         ]
     )
 
@@ -121,3 +127,7 @@ def test_inference_affinity(trainfile, testfile, dataroot, tmpdir, device):
     )
 
     inference.inference(args)
+
+    # Confirm inference output files exist
+    assert os.path.isfile(os.path.join(tmpdir, "inference.csv"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_inference.csv"))

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,3 +1,6 @@
+import os
+
+import pandas as pd
 import pytest
 
 from gnina import training
@@ -54,6 +57,14 @@ def test_training(trainfile, dataroot, tmpdir, device):
 
     training.training(args)
 
+    # Check presence of output files
+    assert os.path.isfile(os.path.join(tmpdir, "training.log"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_train.csv"))
+    assert not os.path.isfile(os.path.join(tmpdir, "metrics_test.csv"))  # No test file
+
+    df_train = pd.read_csv(os.path.join(tmpdir, "metrics_train.csv"))
+    assert len(df_train) == 2
+
 
 def test_training_with_test(trainfile, dataroot, tmpdir, device):
     # Do not shuffle examples randomly when loading the batch
@@ -83,6 +94,17 @@ def test_training_with_test(trainfile, dataroot, tmpdir, device):
     )
 
     training.training(args)
+
+    # Check presence of output files
+    assert os.path.isfile(os.path.join(tmpdir, "training.log"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_train.csv"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_test.csv"))
+
+    df_train = pd.read_csv(os.path.join(tmpdir, "metrics_train.csv"))
+    df_test = pd.read_csv(os.path.join(tmpdir, "metrics_test.csv"))
+
+    assert len(df_train) == 2
+    assert len(df_test) == 2
 
 
 def test_training_pose_and_affinity(trainfile, dataroot, tmpdir, device):
@@ -114,6 +136,14 @@ def test_training_pose_and_affinity(trainfile, dataroot, tmpdir, device):
     )
 
     training.training(args)
+
+    # Check presence of output files
+    assert os.path.isfile(os.path.join(tmpdir, "training.log"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_train.csv"))
+    assert not os.path.isfile(os.path.join(tmpdir, "metrics_test.csv"))
+
+    df_train = pd.read_csv(os.path.join(tmpdir, "metrics_train.csv"))
+    assert len(df_train) == 2
 
 
 def test_training_lr_scheduler(trainfile, dataroot, tmpdir, device, capsys):
@@ -158,3 +188,14 @@ def test_training_lr_scheduler(trainfile, dataroot, tmpdir, device, capsys):
     assert "Learning rate: 0.1" in captured.out  # Initial learning rate
     assert "Learning rate: 0.01" in captured.out  # Updated learning rate
     assert "Learning rate: 0.001" in captured.out  # Updated learning rate
+
+    # Check presence of output files
+    assert os.path.isfile(os.path.join(tmpdir, "training.log"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_train.csv"))
+    assert os.path.isfile(os.path.join(tmpdir, "metrics_test.csv"))
+
+    df_train = pd.read_csv(os.path.join(tmpdir, "metrics_train.csv"))
+    df_test = pd.read_csv(os.path.join(tmpdir, "metrics_test.csv"))
+
+    assert len(df_train) == 5
+    assert len(df_test) == 5


### PR DESCRIPTION
## Description
This PR adds storage of different metrics when they are evaluated during training (and also inference, although that's a single step) and prints out the metrics at the end of training for easy analysis.

This avoids the need to parse the log file.

## PR Checklist
- [x] Tests
- [x] Documentation
