### PR TITLE
Use mamba in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,12 +25,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
-    - name: Additional info about the build
+    - name: Infos
       shell: bash
       run: |
         uname -a
@@ -39,13 +39,13 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/gninatorch.yaml
-
-        channels: conda-forge,defaults
-
+        environment-file: devtools/conda-envs/gninatorch-CI.yaml
+        mamba-version: "*"
+        channels: conda-forge,pytorch
+        channel-priority: true
         activate-environment: gninatorch
         auto-update-conda: false
         auto-activate-base: false

--- a/devtools/conda-envs/gninatorch-CI.yaml
+++ b/devtools/conda-envs/gninatorch-CI.yaml
@@ -3,21 +3,15 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
-  - python
   - pip
-  - ipython
 
   - numpy
-  - scipy
-  - pandas
 
-  - cudatoolkit=11.3
-  - pytorch=1.11
+  - pytorch
   - ignite
   - torchvision
 
   - mlflow
-
   - scikit-learn>=1.0
 
   - tqdm
@@ -29,8 +23,3 @@ dependencies:
   - pytest
   - pytest-cov
   - codecov
-  - black
-  - mypy
-  - flake8
-  - isort
-  - pre-commit


### PR DESCRIPTION
## Description

Switch from `conda` to `mamba` in CI and strip down CI environment to bare minimum.