### PR TITLE
Add support for dense models and GNINA default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,26 @@ PyTorch implementation of [GNINA](https://github.com/gnina/gnina) scoring functi
 
 If you are using `gnina-torch`, please consider citing the following references:
 
-> Protein–Ligand Scoring with Convolutional Neural Networks,
+> Protein-Ligand Scoring with Convolutional Neural Networks,
 > M. Ragoza, J. Hochuli, E. Idrobo, J. Sunseri, and D. R. Koes, *J. Chem. Inf. Model.* 2017, 57 (4), 942-957.
 > DOI: [10.1021/acs.jcim.6b00740](https://pubs.acs.org/doi/full/10.1021/acs.jcim.6b00740)
 
 > libmolgrid: Graphics Processing Unit Accelerated Molecular Gridding for Deep Learning Applications
-> J. Sunseri and D. R. Koes, *J. Chem. Inf. Model.* 2020, 60 (3), 1079–1084.
+> J. Sunseri and D. R. Koes, *J. Chem. Inf. Model.* 2020, 60 (3), 1079-1084.
 > DOI: [10.1021/acs.jcim.9b01145](https://pubs.acs.org/doi/10.1021/acs.jcim.9b01145)
 
 If you are using the pre-trained `default2018` and `dense` models from [GNINA](https://github.com/gnina/gnina), please consider citing the following reference as well:
 
 > Three-Dimensional Convolutional Neural Networks and a Cross-Docked Data Set for Structure-Based Drug Design,
-> P. G. Francoeur, T. Masuda, J. Sunseri, A. Jia, R. B> Iovanisci, I. Snyder, and D. R. Koes, *J. Chem. Inf. Model.* 2020, 60 (9), 4200-4215.
-> DOI: [10.1021/acs.jcim.0c00411](https://doi.org/10.1021/acs.jcim.0c00411)
+> P. G. Francoeur, T. Masuda, J. Sunseri, A. Jia, R. B. Iovanisci, I. Snyder, and D. R. Koes, *J. Chem. Inf. Model.* 2020, 60 (9), 4200-4215.
+> DOI: [10.1021/acs.jcim.0c00411](https://doi.org/10.1021/acs.jcim.0c0041)
+
+If you are using the pre-trained `default` model ensemble from [GNINA](https://github.com/gnina/gnina), please consider citing the following reference as well:
+
+> GNINA 1.0: molecular docking with deep learning,
+> A. T. McNutt, P. Francoeur, R. Aggarwal, T. Masuda, R. Meli, M. Ragoza, J. Sunseri, D. R. Koes,
+> *J. Cheminform.* 2021, 13 (43).
+> DOI: [10.1186/s13321-021-00522-2](https://doi.org/10.1186/s13321-021-00522-2)
 
 ## Installation
 
@@ -66,18 +73,11 @@ The folder `gninatorch/weights` contains pre-trained models from [GNINA](https:/
 Pre-trained GNINA models can be loaded as follows:
 
 ```python
-from gninatorch.gnina import load_gnina_model
+from gninatorch.gnina import setup_gnina_model
 
-model = load_gnina_model(MODEL_NAME)
+model = setup_gnina_model(MODEL)```
 ```
-
-Pre-trainde GNINA models can be loades as an ensemble as follows:
-
-```python
-from gninatorch.gnina import load_gnina_models
-
-model_ensemble = load_gnina_models([MODEL_NAME_1, MODEL_NAME_2, ...])
-```
+where `MODEL` corresponds to the `--cnn` argument in [GNINA](https://github.com/gnina/gnina).
 
 A single model will return `log_CNNscore` and `CNNaffinity`, while an ensemble of models will return `log_CNNscore`, `CNNaffinity`, and `CNNvariance`.
 

--- a/gninatorch/gnina.py
+++ b/gninatorch/gnina.py
@@ -96,6 +96,11 @@ def _load_gnina_model_file(
     num_voxels: int
         Number of voxels per grid dimension
 
+    Raises
+    ------
+    ValueError
+        if model name is unknown
+
     Note
     ----
     All GNINA default models perform both pose prediction and binding affinity
@@ -217,19 +222,6 @@ def options(args: Optional[List[str]] = None):
     parser.add_argument("--dimension", type=float, default=23.5, help="Grid dimension")
     parser.add_argument("--resolution", type=float, default=0.5, help="Grid resolution")
     parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
-
-    parser.add_argument(
-        "--ligmolcache",
-        type=str,
-        default="",
-        help=".molcache2 file for ligands",
-    )
-    parser.add_argument(
-        "--recmolcache",
-        type=str,
-        default="",
-        help=".molcache2 file for receptors",
-    )
 
     parser.add_argument(
         "--no_cache",

--- a/gninatorch/gnina.py
+++ b/gninatorch/gnina.py
@@ -276,7 +276,7 @@ def setup_gnina_model(
             "general_default2018_3",
             "dense_3",
             "crossdock_default2018",
-            "redock_default2018",
+            "redock_default2018_2",
         ]
 
         model = load_gnina_models(names)

--- a/gninatorch/gnina.py
+++ b/gninatorch/gnina.py
@@ -224,6 +224,19 @@ def options(args: Optional[List[str]] = None):
     parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
 
     parser.add_argument(
+        "--ligmolcache",
+        type=str,
+        default="",
+        help=".molcache2 file for ligands",
+    )
+    parser.add_argument(
+        "--recmolcache",
+        type=str,
+        default="",
+        help=".molcache2 file for receptors",
+    )
+
+    parser.add_argument(
         "--no_cache",
         action="store_false",
         help="Disable structure caching",
@@ -234,7 +247,7 @@ def options(args: Optional[List[str]] = None):
 
 
 def setup_gnina_model(
-    cnn: str, dimension: float, resolution: float
+    cnn: str = "default", dimension: float = 23.5, resolution: float = 0.5
 ) -> Union[nn.Module, bool]:
     """
     Load model or ensemble of models.
@@ -271,7 +284,7 @@ def setup_gnina_model(
             "redock_default2018_2",
         ]
 
-        model = load_gnina_models(names)
+        model = load_gnina_models(names, dimension, resolution)
     elif "ensemble" in cnn:
         ensemble = True
 
@@ -282,7 +295,7 @@ def setup_gnina_model(
         model = load_gnina_models(names, dimension, resolution)
     else:
         ensemble = False
-        model = load_gnina_model(cnn)
+        model = load_gnina_model(cnn, dimension, resolution)
 
     # Put model in evaluation mode
     # This is essential to have the BatchNorm layers in the correct state

--- a/tests/test_gnina.py
+++ b/tests/test_gnina.py
@@ -133,13 +133,13 @@ def test_gnina_model_prediction(
 
     # Check that scores sum to one
     assert torch.allclose(
-        torch.exp(log_pose).sum(dim=-1), torch.ones_like(affinity), atol=1e-6
+        torch.exp(log_pose).sum(dim=-1), torch.ones_like(affinity), atol=1e-5
     )
 
     score = torch.exp(log_pose)[:, -1].cpu().numpy()
 
     assert np.allclose(1 - score, 1 - CNNscore, atol=1e-5)
-    assert np.allclose(affinity.cpu().numpy(), CNNaffinity, atol=1e-6)
+    assert np.allclose(affinity.cpu().numpy(), CNNaffinity, atol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -216,16 +216,16 @@ def test_gnina_model_prediction_ensemble(
     assert affinity_var.shape == (3,)
 
     assert torch.allclose(
-        torch.exp(log_pose).sum(dim=-1), torch.ones_like(affinity), atol=1e-6
+        torch.exp(log_pose).sum(dim=-1), torch.ones_like(affinity), atol=1e-5
     )
 
     score = torch.exp(log_pose)[:, -1].cpu().numpy()
 
     assert np.allclose(1 - score, 1 - CNNscore, atol=1e-5)
-    assert np.allclose(affinity.cpu().numpy(), CNNaffinity, atol=1e-6)
+    assert np.allclose(affinity.cpu().numpy(), CNNaffinity, atol=1e-5)
 
     # Compare 1-affinity_var because variance is expected to be small
-    assert np.allclose(1 - affinity_var.cpu().numpy(), 1 - CNNvariance, atol=1e-6)
+    assert np.allclose(1 - affinity_var.cpu().numpy(), 1 - CNNvariance, atol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -275,7 +275,7 @@ def test_gnina(
     # CI sometimes fail with 0.43468 instead of 0.43467
     # atol reduced to 1e-5 to avoid this random failure (numerical errors)
     assert np.allclose(1 - score, 1 - CNNscore, atol=1e-5)
-    assert np.allclose(affinity, CNNaffinity, atol=1e-6)
+    assert np.allclose(affinity, CNNaffinity, atol=1e-5)
 
 
 @pytest.mark.parametrize(
@@ -344,8 +344,8 @@ def test_gnina_ensemble(
     variance = np.array([float(s) for s in variance_re])
 
     assert np.allclose(1 - score, 1 - CNNscore, atol=1e-5)
-    assert np.allclose(affinity, CNNaffinity, atol=1e-6)
-    assert np.allclose(1 - variance, 1 - CNNvariance, atol=1e-6)
+    assert np.allclose(affinity, CNNaffinity, atol=1e-5)
+    assert np.allclose(1 - variance, 1 - CNNvariance, atol=1e-5)
 
 
 def test_header(capsys):

--- a/tests/test_gnina.py
+++ b/tests/test_gnina.py
@@ -305,12 +305,12 @@ def test_gnina(
             np.array([2.62781, 1.96368, 2.26030]),
             np.array([0.21371, 0.46775, 0.19200]),
         ),
-        #        (
-        #            "default", # GNINA default model from McNutt et al. (2021)
-        #            np.array([0.66093, 0.43392, 0.44233]),
-        #            np.array([1.82328, 1.49802, 1.54133]),
-        #            np.array([0.56169, 0.21729, 0.38851]),
-        #        )
+        (
+            "default",  # GNINA default model from McNutt et al. (2021)
+            np.array([0.66093, 0.43392, 0.44233]),
+            np.array([1.82328, 1.49802, 1.54133]),
+            np.array([0.56169, 0.21729, 0.38851]),
+        ),
     ],
 )
 def test_gnina_ensemble(


### PR DESCRIPTION
## Description
Thanks to @drewnutt #43 , the correct weights for the `dense` models are now available, which allow to support the `dense` models alongside `default2017` and `default2018`. More importantly, this allows to build the `default` model ensemble, thus reproducing all results obtained with GNINA.

## PR Checklist
- [x] Tests
- [x] Documentation
